### PR TITLE
Add CRAN installation to README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -19,7 +19,7 @@ library(lobstr)
 [![Travis-CI Build Status](https://travis-ci.org/r-lib/lobstr.svg?branch=master)](https://travis-ci.org/r-lib/lobstr)
 [![Coverage status](https://codecov.io/gh/r-lib/lobstr/branch/master/graph/badge.svg)](https://codecov.io/github/r-lib/lobstr?branch=master)
 
-lobstr provides tool in the same vein as `str()`, tools that allow you to dig into the detail of an object.
+lobstr provides tools in the same vein as `str()`, which allow you to dig into the detail of an object.
 
 ## Installation
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -23,6 +23,12 @@ lobstr provides tool in the same vein as `str()`, tools that allow you to dig in
 
 ## Installation
 
+Install the released version of lobstr from CRAN:
+
+``` r
+install.packages("lobstr")
+```
+
 You can install the development version with:
 
 ``` r

--- a/README.md
+++ b/README.md
@@ -66,16 +66,16 @@ digging into the underlying \_\_ref\_\_erences:
 x <- 1:1e6
 y <- list(x, x, x)
 ref(y)
-#> █ [1:0x7fb2dd0fa2c8] <list> 
-#> ├─[2:0x7fb2dc0a9458] <int> 
-#> ├─[2:0x7fb2dc0a9458] 
-#> └─[2:0x7fb2dc0a9458]
+#> █ [1:0x7febd378d2c8] <list> 
+#> ├─[2:0x7febd3a88258] <int> 
+#> ├─[2:0x7febd3a88258] 
+#> └─[2:0x7febd3a88258]
 
 e <- rlang::env()
 e$self <- e
 ref(e)
-#> █ [1:0x7fb2dbc4f8b0] <env> 
-#> └─self = [1:0x7fb2dbc4f8b0]
+#> █ [1:0x7febd50320b0] <env> 
+#> └─self = [1:0x7febd50320b0]
 ```
 
 A related tool is `obj_size()`, which computes the size of an object
@@ -83,9 +83,9 @@ taking these shared references into account:
 
 ``` r
 obj_size(x)
-#> 4,000,048 B
+#> 680 B
 obj_size(y)
-#> 4,000,128 B
+#> 760 B
 ```
 
 ### Call stack trees

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Status](https://travis-ci.org/r-lib/lobstr.svg?branch=master)](https://travis-ci
 [![Coverage
 status](https://codecov.io/gh/r-lib/lobstr/branch/master/graph/badge.svg)](https://codecov.io/github/r-lib/lobstr?branch=master)
 
-lobstr provides tool in the same vein as `str()`, tools that allow you
-to dig into the detail of an object.
+lobstr provides tools in the same vein as `str()`, which allow you to
+dig into the detail of an object.
 
 ## Installation
 
@@ -66,16 +66,16 @@ digging into the underlying \_\_ref\_\_erences:
 x <- 1:1e6
 y <- list(x, x, x)
 ref(y)
-#> █ [1:0x7fdb5fe92018] <list> 
-#> ├─[2:0x7fdb5e02f090] <int> 
-#> ├─[2:0x7fdb5e02f090] 
-#> └─[2:0x7fdb5e02f090]
+#> █ [1:0x7fb2dd0fa2c8] <list> 
+#> ├─[2:0x7fb2dc0a9458] <int> 
+#> ├─[2:0x7fb2dc0a9458] 
+#> └─[2:0x7fb2dc0a9458]
 
 e <- rlang::env()
 e$self <- e
 ref(e)
-#> █ [1:0x7fdb60839ea8] <env> 
-#> └─self = [1:0x7fdb60839ea8]
+#> █ [1:0x7fb2dbc4f8b0] <env> 
+#> └─self = [1:0x7fb2dbc4f8b0]
 ```
 
 A related tool is `obj_size()`, which computes the size of an object

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ to dig into the detail of an object.
 
 ## Installation
 
+Install the released version of lobstr from CRAN:
+
+``` r
+install.packages("lobstr")
+```
+
 You can install the development version with:
 
 ``` r
@@ -60,16 +66,16 @@ digging into the underlying \_\_ref\_\_erences:
 x <- 1:1e6
 y <- list(x, x, x)
 ref(y)
-#> █ [1:0x7f9adf16b078] <list> 
-#> ├─[2:0x7f9add3d9b48] <int> 
-#> ├─[2:0x7f9add3d9b48] 
-#> └─[2:0x7f9add3d9b48]
+#> █ [1:0x7fdb5fe92018] <list> 
+#> ├─[2:0x7fdb5e02f090] <int> 
+#> ├─[2:0x7fdb5e02f090] 
+#> └─[2:0x7fdb5e02f090]
 
 e <- rlang::env()
 e$self <- e
 ref(e)
-#> █ [1:0x7f9ada2fc7e8] <env> 
-#> └─self = [1:0x7f9ada2fc7e8]
+#> █ [1:0x7fdb60839ea8] <env> 
+#> └─self = [1:0x7fdb60839ea8]
 ```
 
 A related tool is `obj_size()`, which computes the size of an object
@@ -77,9 +83,9 @@ taking these shared references into account:
 
 ``` r
 obj_size(x)
-#> 680 B
+#> 4,000,048 B
 obj_size(y)
-#> 760 B
+#> 4,000,128 B
 ```
 
 ### Call stack trees
@@ -92,8 +98,8 @@ g <- function(x) h(x)
 h <- function(x) x
 f(cst())
 #> █
-#> ├─f(cst())
-#> │ └─g(x)
-#> │   └─h(x)
-#> └─cst()
+#> ├─global::f(cst())
+#> │ └─global::g(x)
+#> │   └─global::h(x)
+#> └─lobstr::cst()
 ```


### PR DESCRIPTION
* Add instructions for installing from CRAN to README, since lobstr is now released.