### PR TITLE
Avoid calling custom methods when ref()ing recursively

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # lobstr (development version)
 
+* `ref()` now handles custom classes properly (@yutannihilation, #36)
+
 # lobstr 1.0.1
 
 * `ast()` prints scalar integer and complex more accurately (#24)

--- a/R/ref.R
+++ b/R/ref.R
@@ -52,7 +52,10 @@ ref_tree <- function(x, character = FALSE, seen = child_env(emptyenv()), layout 
     return(desc)
   }
 
-  # recursive case
+  # Remove classes to avoid custom methods (note that environments cannot be unclasse()ed)
+  attr(x, "class") <- NULL
+
+  # recursive cases
   if (is.list(x)) {
     subtrees <- lapply(x, ref_tree, layout = layout, seen = seen, character = character)
   } else if (is.environment(x)) {

--- a/R/ref.R
+++ b/R/ref.R
@@ -53,7 +53,7 @@ ref_tree <- function(x, character = FALSE, seen = child_env(emptyenv()), layout 
   }
 
   # Remove classes to avoid custom methods (note that environments cannot be unclasse()ed)
-  # attr(x, "class") <- NULL
+  attr(x, "class") <- NULL
 
   # recursive cases
   if (is.list(x)) {

--- a/R/ref.R
+++ b/R/ref.R
@@ -53,7 +53,7 @@ ref_tree <- function(x, character = FALSE, seen = child_env(emptyenv()), layout 
   }
 
   # Remove classes to avoid custom methods (note that environments cannot be unclasse()ed)
-  attr(x, "class") <- NULL
+  # attr(x, "class") <- NULL
 
   # recursive cases
   if (is.list(x)) {

--- a/tests/testthat/test-ref.R
+++ b/tests/testthat/test-ref.R
@@ -45,3 +45,21 @@ test_that("can display ref to global string pool on request", {
     print = TRUE
   )
 })
+
+test_that("custom methods are never called (#30)", {
+  `[[.foo` <- function(...) stop("you are dead!")
+  `as.list.foo` <- function(...) stop("you are dead!")
+
+  x <- 1:10
+  y <- list(x, x)
+  class(y) <- "foo"
+
+  expect_error(ref(y), NA)
+
+  e <- env(a = 1:10)
+  e$b <- e$a
+  e$c <- e
+  class(e) <- "foo"
+
+  expect_error(ref(e), NA)
+})

--- a/tests/testthat/test-ref.R
+++ b/tests/testthat/test-ref.R
@@ -47,19 +47,15 @@ test_that("can display ref to global string pool on request", {
 })
 
 test_that("custom methods are never called (#30)", {
-  `[[.foo` <- function(...) stop("you are dead!")
-  `as.list.foo` <- function(...) stop("you are dead!")
-
-  x <- 1:10
-  y <- list(x, x)
-  class(y) <- "foo"
-
-  expect_error(ref(y), NA)
+  # `[[.numeric_number` causes infinite recursion
+  expect_error(ref(package_version("1.1.1")), NA)
 
   e <- env(a = 1:10)
   e$b <- e$a
   e$c <- e
-  class(e) <- "foo"
+
+  # `as.list.data.frame`(<environemnt>, ...) fails
+  class(e) <- "data.frame"
 
   expect_error(ref(e), NA)
 })


### PR DESCRIPTION
Fix #30 

Currently, `ref_tree()` is called recursively by `lapply()`. But, if the object has some custom methods, subsetting or coercing to a list might lead to unexpected results. This PR strips the class before diving into the recursion.